### PR TITLE
Added option SQLW_USE_JSON_STRING_RESULT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 build
 .cache
 compile_commands.json
-include/local/cmake_vars.h
+include/sqlw/cmake_vars.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,15 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 endif()
 
 option(SQLW_BUILD_TESTS "Build test programs" ${SQLW_STANDALONE})
+option(SQLW_USE_JSON_STRING_RESULT "Build JsonStringResult" ON)
 
 set(SQLW_EXEC_LIMIT 256 CACHE STRING "Default limit for consecutive queries and for SELECT results" FORCE)
+
+set(SQLW_USE_JSON_STRING_RESULT_VAR 1)
+
+if (NOT SQLW_USE_JSON_STRING_RESULT)
+	set(SQLW_USE_JSON_STRING_RESULT_VAR 0)
+endif()
 
 add_library(
 	sqlw
@@ -20,7 +27,7 @@ add_library(
 		src/connection.cpp
 		src/statement.cpp
 		src/status.cpp
-		src/json_string_result.cpp
+		$<IF:$<BOOL:${SQLW_USE_JSON_STRING_RESULT}>,src/json_string_result.cpp,>
 )
 
 target_include_directories(

--- a/include/sqlw/cmake_vars.h
+++ b/include/sqlw/cmake_vars.h
@@ -1,7 +1,0 @@
-#ifndef SQLW_CMAKE_VARS_H_
-#define SQLW_CMAKE_VARS_H_
-
-#define SQLW_EXEC_LIMIT 256
-
-#endif // SQLW_CMAKE_VARS_H_
-

--- a/include/sqlw/cmake_vars.h.in
+++ b/include/sqlw/cmake_vars.h.in
@@ -3,5 +3,9 @@
 
 #define SQLW_EXEC_LIMIT @SQLW_EXEC_LIMIT@
 
+#if @SQLW_USE_JSON_STRING_RESULT_VAR@ == 1
+#define SQLW_JSON_STRING_RESULT_H_
+#endif
+
 #endif // SQLW_CMAKE_VARS_H_
 


### PR DESCRIPTION
Did this because on mac when trying to compile src/json_string_result.cpp with compiler that was provided with xcode command line tools said compiler warns "no member named 'view' in 'std::stringstream'".
Setting option `SQLW_USE_JSON_STRING_RESULT` to OFF excludes json_string_result.cpp from building.