### PR TITLE
Sun May  3 19:51:37 +05 2026

### DIFF
--- a/include/sqlw/forward.hpp
+++ b/include/sqlw/forward.hpp
@@ -26,6 +26,8 @@ enum class Code : int
     ROLLBACK_ERROR,
     RELEASE_ERROR,
     UNUSED_PARAMETERS_ERROR,
+    PARAM_CONVERT_TO_INT_ERROR,
+    PARAM_CONVERT_TO_DOUBLE_ERROR,
 };
 
 enum class Condition : int
@@ -35,6 +37,7 @@ enum class Condition : int
     DONE,
     ERROR,
     CLOSED_HANDLE,
+    INVALID_PARAM,
 };
 
 std::error_code make_error_code(sqlw::status::Code ec);

--- a/include/sqlw/statement.hpp
+++ b/include/sqlw/statement.hpp
@@ -5,6 +5,7 @@
 #include "sqlw/connection.hpp"
 #include "sqlw/forward.hpp"
 #include <concepts>
+#include <cstdint>
 #include <functional>
 #include <gsl/util>
 #include <memory>
@@ -12,7 +13,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
-#include <tuple>
+// #include <tuple>
 #include <type_traits>
 #include <utility>
 
@@ -47,6 +48,12 @@ class Statement
     typedef statement::internal::callback_t callback_t;
     typedef statement::internal::bindable_t bindable_t;
     typedef std::span<const bindable_t> unused_params_t;
+
+    struct Meta
+    {
+        uint64_t last_ok_prepare_idx{0};
+        uint64_t last_ok_bind_idx{0};
+    };
 
     Statement(Connection* connection);
 
@@ -116,10 +123,11 @@ class Statement
      * @note This function can bind parameters only for the first
      * prepared statement.
      */
-    template <typename... ThingsToBind>
-        requires statement::internal::are_bindable<ThingsToBind...>
-    auto operator()(std::string_view sql, std::tuple<ThingsToBind...>&& params)
-        -> std::error_code;
+    // template <typename... ThingsToBind>
+    //     requires statement::internal::are_bindable<ThingsToBind...>
+    // auto operator()(std::string_view sql, std::tuple<ThingsToBind...>&&
+    // params)
+    //     -> std::error_code;
 
     /**
      * Prepares and executes all statements passed in `sql`.
@@ -129,15 +137,20 @@ class Statement
      * @note This function can bind parameters only for the first
      * prepared statement.
      */
-    template <typename... ThingsToBind>
-        requires statement::internal::are_bindable<ThingsToBind...>
-    auto operator()(
-        std::string_view sql,
-        callback_t callback,
-        std::tuple<ThingsToBind...>&& params) -> std::error_code;
+    // template <typename... ThingsToBind>
+    //     requires statement::internal::are_bindable<ThingsToBind...>
+    // auto operator()(
+    //     std::string_view sql,
+    //     callback_t callback,
+    //     std::tuple<ThingsToBind...>&& params) -> std::error_code;
 
     auto operator()(callback_t = nullptr, unused_params_t = {}) noexcept
         -> std::error_code;
+
+    auto meta() const -> Meta
+    {
+        return this->m_meta;
+    }
 
   private:
     Connection* m_connection{nullptr};
@@ -145,81 +158,84 @@ class Statement
     std::error_code m_status{status::Code{}};
     gsl::owner<const char*> m_unused_sql{nullptr};
     std::string_view m_sql_string{};
+    Meta m_meta{};
 
-    template <typename T>
-    auto internal_bind(sqlw::Statement& stmt, const T& x, size_t index) -> bool;
+    // template <typename T>
+    // auto internal_bind(sqlw::Statement& stmt, const T& x, size_t index) ->
+    // bool;
 };
 
-template <typename T>
-bool Statement::internal_bind(sqlw::Statement& stmt, const T& x, size_t i)
-{
-    if constexpr (
-        std::is_integral_v<std::remove_cvref_t<T>> ||
-        std::is_floating_point_v<std::remove_cvref_t<T>>)
-    {
-        stmt.bind(i, x);
-    }
-    else
-    {
-        stmt.bind(i, x.first, x.second);
-    }
+// template <typename T>
+// bool Statement::internal_bind(sqlw::Statement& stmt, const T& x, size_t i)
+// {
+//     if constexpr (
+//         std::is_integral_v<std::remove_cvref_t<T>> ||
+//         std::is_floating_point_v<std::remove_cvref_t<T>>)
+//     {
+//         stmt.bind(i, x);
+//     }
+//     else
+//     {
+//         stmt.bind(i, x.first, x.second);
+//     }
+//
+//     return sqlw::status::Condition::OK == stmt.status();
+// }
 
-    return sqlw::status::Condition::OK == stmt.status();
-}
+// template <typename... ThingsToBind>
+//     requires statement::internal::are_bindable<ThingsToBind...>
+// auto Statement::operator()(
+//     std::string_view sql,
+//     callback_t callback,
+//     std::tuple<ThingsToBind...>&& params) -> std::error_code
+// {
+//     this->prepare(sql);
+//
+//     if (sqlw::status::Condition::OK != m_status)
+//     {
+//         return m_status;
+//     }
+//
+//     if constexpr (std::tuple_size<std::remove_cvref_t<decltype(params)>>() >
+//     0)
+//     {
+//         size_t expected_param_count = sqlite3_bind_parameter_count(m_stmt);
+//         size_t i = 1;
+//         std::apply(
+//             [&](auto&&... param) {
+//                 ((i <= expected_param_count &&
+//                   this->internal_bind(*this, param, i) && (++i)) &&
+//                  ...);
+//             },
+//             params);
+//
+//         if (i <= std::tuple_size<std::remove_cvref_t<decltype(params)>>())
+//         {
+//             m_status = sqlw::status::Code::UNUSED_PARAMETERS_ERROR;
+//         }
+//
+//         if (sqlw::status::Condition::OK != m_status)
+//         {
+//             return m_status;
+//         }
+//     }
+//
+//     if (sqlw::status::Condition::OK != m_status)
+//     {
+//         return m_status;
+//     }
+//
+//     return operator()(callback);
+// }
 
-template <typename... ThingsToBind>
-    requires statement::internal::are_bindable<ThingsToBind...>
-auto Statement::operator()(
-    std::string_view sql,
-    callback_t callback,
-    std::tuple<ThingsToBind...>&& params) -> std::error_code
-{
-    this->prepare(sql);
-
-    if (sqlw::status::Condition::OK != m_status)
-    {
-        return m_status;
-    }
-
-    if constexpr (std::tuple_size<std::remove_cvref_t<decltype(params)>>() > 0)
-    {
-        size_t expected_param_count = sqlite3_bind_parameter_count(m_stmt);
-        size_t i = 1;
-        std::apply(
-            [&](auto&&... param) {
-                ((i <= expected_param_count &&
-                  this->internal_bind(*this, param, i) && (++i)) &&
-                 ...);
-            },
-            params);
-
-        if (i <= std::tuple_size<std::remove_cvref_t<decltype(params)>>())
-        {
-            m_status = sqlw::status::Code::UNUSED_PARAMETERS_ERROR;
-        }
-
-        if (sqlw::status::Condition::OK != m_status)
-        {
-            return m_status;
-        }
-    }
-
-    if (sqlw::status::Condition::OK != m_status)
-    {
-        return m_status;
-    }
-
-    return operator()(callback);
-}
-
-template <typename... ThingsToBind>
-    requires statement::internal::are_bindable<ThingsToBind...>
-auto Statement::operator()(
-    std::string_view sql,
-    std::tuple<ThingsToBind...>&& params) -> std::error_code
-{
-    return operator()(sql, nullptr, std::move(params));
-}
+// template <typename... ThingsToBind>
+//     requires statement::internal::are_bindable<ThingsToBind...>
+// auto Statement::operator()(
+//     std::string_view sql,
+//     std::tuple<ThingsToBind...>&& params) -> std::error_code
+// {
+//     return operator()(sql, nullptr, std::move(params));
+// }
 
 } // namespace sqlw
 

--- a/include/sqlw/transaction.hpp
+++ b/include/sqlw/transaction.hpp
@@ -2,11 +2,11 @@
 #define SQLW_TRANSACTION_H_
 
 #include "sqlw/connection.hpp"
-#include "sqlw/forward.hpp"
+// #include "sqlw/forward.hpp"
 #include "sqlw/statement.hpp"
 #include <span>
 #include <system_error>
-#include <tuple>
+// #include <tuple>
 #include <type_traits>
 #include <utility>
 
@@ -68,11 +68,11 @@ class Transaction
      * @note This function can bind parameters only for the first
      * prepared statement.
      */
-    template <typename... ThingsToBind>
-        requires sqlw::statement::internal::are_bindable<ThingsToBind...>
-    auto operator()(
-        std::string_view sql,
-        std::tuple<ThingsToBind...>&&) noexcept -> std::error_code;
+    // template <typename... ThingsToBind>
+    //     requires sqlw::statement::internal::are_bindable<ThingsToBind...>
+    // auto operator()(
+    //     std::string_view sql,
+    //     std::tuple<ThingsToBind...>&&) noexcept -> std::error_code;
 
     /**
      * Prepares and executes all statements passed in `sql`.
@@ -82,59 +82,75 @@ class Transaction
      * @note This function can bind parameters only for the first
      * prepared statement.
      */
-    template <typename... ThingsToBind>
-        requires sqlw::statement::internal::are_bindable<ThingsToBind...>
-    auto operator()(
-        std::string_view sql,
-        Statement::callback_t,
-        std::tuple<ThingsToBind...>&&) noexcept -> std::error_code;
+    // template <typename... ThingsToBind>
+    //     requires sqlw::statement::internal::are_bindable<ThingsToBind...>
+    // auto operator()(
+    //     std::string_view sql,
+    //     Statement::callback_t,
+    //     std::tuple<ThingsToBind...>&&) noexcept -> std::error_code;
+
+    auto target_stmt_error_message() const -> std::string_view
+    {
+        return m_target_stmt_error_message;
+    }
+
+    auto target_stmt_meta() const -> sqlw::Statement::Meta
+    {
+        return m_target_stmt_meta;
+    }
 
   private:
     sqlw::Connection* m_con{nullptr};
+    std::string m_target_stmt_error_message{};
+    sqlw::Statement::Meta m_target_stmt_meta{};
 };
 
-template <typename... ThingsToBind>
-    requires sqlw::statement::internal::are_bindable<ThingsToBind...>
-std::error_code Transaction::operator()(
-    std::string_view sql,
-    Statement::callback_t callback,
-    std::tuple<ThingsToBind...>&& bindables) noexcept
-{
-    sqlw::Statement stmt{m_con};
+// deprecate this ish because:
+// - almost not used;
+// - forces to recompilation;
+// - duplicated code.
+// template <typename... ThingsToBind>
+//     requires sqlw::statement::internal::are_bindable<ThingsToBind...>
+// std::error_code Transaction::operator()(
+//     std::string_view sql,
+//     Statement::callback_t callback,
+//     std::tuple<ThingsToBind...>&& bindables) noexcept
+// {
+//     sqlw::Statement stmt{m_con};
+//
+//     if (stmt("SAVEPOINT _savepoint_") != sqlw::status::Condition::OK)
+//     {
+//         return sqlw::status::Code::SAVEPOINT_ERROR;
+//     }
+//
+//     const auto ec = stmt(sql, callback, std::move(bindables));
+//
+//     if (ec != sqlw::status::Condition::OK)
+//     {
+//         if (stmt("ROLLBACK TO _savepoint_") != sqlw::status::Condition::OK)
+//         {
+//             return sqlw::status::Code::ROLLBACK_ERROR;
+//         }
+//     }
+//     else
+//     {
+//         if (stmt("RELEASE _savepoint_") != sqlw::status::Condition::OK)
+//         {
+//             return sqlw::status::Code::RELEASE_ERROR;
+//         }
+//     }
+//
+//     return ec;
+// }
 
-    if (stmt("SAVEPOINT _savepoint_") != sqlw::status::Condition::OK)
-    {
-        return sqlw::status::Code::SAVEPOINT_ERROR;
-    }
-
-    const auto ec = stmt(sql, callback, std::move(bindables));
-
-    if (ec != sqlw::status::Condition::OK)
-    {
-        if (stmt("ROLLBACK TO _savepoint_") != sqlw::status::Condition::OK)
-        {
-            return sqlw::status::Code::ROLLBACK_ERROR;
-        }
-    }
-    else
-    {
-        if (stmt("RELEASE _savepoint_") != sqlw::status::Condition::OK)
-        {
-            return sqlw::status::Code::RELEASE_ERROR;
-        }
-    }
-
-    return ec;
-}
-
-template <typename... ThingsToBind>
-    requires sqlw::statement::internal::are_bindable<ThingsToBind...>
-std::error_code Transaction::operator()(
-    std::string_view sql,
-    std::tuple<ThingsToBind...>&& bindables) noexcept
-{
-    return operator()(sql, nullptr, std::move(bindables));
-}
+// template <typename... ThingsToBind>
+//     requires sqlw::statement::internal::are_bindable<ThingsToBind...>
+// std::error_code Transaction::operator()(
+//     std::string_view sql,
+//     std::tuple<ThingsToBind...>&& bindables) noexcept
+// {
+//     return operator()(sql, nullptr, std::move(bindables));
+// }
 
 /* template <typename... ThingsToBind> */
 /* requires sqlw::statement::internal::are_bindable<ThingsToBind...> */

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -92,6 +92,11 @@ sqlw::Statement& sqlw::Statement::prepare(std::string_view sql) noexcept
 
     m_status = status::Code{rc};
 
+    if (sqlw::status::Condition::OK != m_status)
+    {
+        m_meta.last_ok_prepare_idx++;
+    }
+
     return *this;
 }
 
@@ -231,7 +236,7 @@ sqlw::Statement& sqlw::Statement::bind(
 
         if (ec != std::errc())
         {
-            m_status = status::Code{SQLITE_MISUSE};
+            m_status = status::Code::PARAM_CONVERT_TO_DOUBLE_ERROR;
             return *this;
         }
 
@@ -249,7 +254,7 @@ sqlw::Statement& sqlw::Statement::bind(
 
         if (fcr.ec != std::errc())
         {
-            m_status = status::Code{SQLITE_MISUSE};
+            m_status = status::Code::PARAM_CONVERT_TO_INT_ERROR;
             return *this;
         }
 
@@ -262,6 +267,11 @@ sqlw::Statement& sqlw::Statement::bind(
     }
 
     m_status = status::Code{rc};
+
+    if (sqlw::status::Condition::OK == m_status)
+    {
+        m_meta.last_ok_bind_idx = idx;
+    }
 
     return *this;
 }

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -29,7 +29,10 @@ struct ErrorCategory : std::error_category
             return "error on savepoint RELEASE";
         case Code::UNUSED_PARAMETERS_ERROR:
             return "some paramaters where not bound";
-            break;
+        case Code::PARAM_CONVERT_TO_INT_ERROR:
+            return "not possible to convert provided parameter to an integer";
+        case Code::PARAM_CONVERT_TO_DOUBLE_ERROR:
+            return "not possible to convert provided parameter to a double";
         }
 
         return sqlite3_errstr(ec);
@@ -58,6 +61,8 @@ struct ConditionCategory : std::error_category
             return "error while performing an operation";
         case C::CLOSED_HANDLE:
             return "object's handle is closed";
+        case Condition::INVALID_PARAM:
+            return "bound parameter is invalid";
         }
 
         return "(unknown condition)";
@@ -87,6 +92,9 @@ struct ConditionCategory : std::error_category
             return ec.value() == SQLITE_ROW;
         case Condition::CLOSED_HANDLE:
             return ec == Code::CLOSED_HANDLE;
+        case Condition::INVALID_PARAM:
+            return ec == Code::PARAM_CONVERT_TO_DOUBLE_ERROR ||
+                   ec == Code::PARAM_CONVERT_TO_INT_ERROR;
         default:
             return false;
         }

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -1,29 +1,48 @@
 #include "sqlw/transaction.hpp"
+#include "sqlw/forward.hpp"
 
 std::error_code sqlw::Transaction::operator()(
     std::string_view sql,
     sqlw::Statement::callback_t callback,
     std::span<const sqlw::Statement::bindable_t> params) noexcept
 {
-    sqlw::Statement stmt{m_con};
 
-    if (stmt("SAVEPOINT _savepoint_") != sqlw::status::Condition::OK)
+    if (sqlw::Statement{m_con}("SAVEPOINT _savepoint_") !=
+        sqlw::status::Condition::OK)
     {
         return sqlw::status::Code::SAVEPOINT_ERROR;
     }
 
+    sqlw::Statement stmt{m_con};
+
     const auto ec = stmt(sql, callback, params);
+
+    m_target_stmt_meta = stmt.meta();
 
     if (ec != sqlw::status::Condition::OK)
     {
-        if (stmt("ROLLBACK TO _savepoint_") != sqlw::status::Condition::OK)
+        if (nullptr != m_con)
+        {
+            if (ec == sqlw::status::Condition::INVALID_PARAM)
+            {
+                m_target_stmt_error_message = ec.message();
+            }
+            else
+            {
+                m_target_stmt_error_message = sqlite3_errmsg(m_con->handle());
+            }
+        }
+
+        if (sqlw::Statement{m_con}("ROLLBACK TO _savepoint_") !=
+            sqlw::status::Condition::OK)
         {
             return sqlw::status::Code::ROLLBACK_ERROR;
         }
     }
     else
     {
-        if (stmt("RELEASE _savepoint_") != sqlw::status::Condition::OK)
+        if (sqlw::Statement{m_con}("RELEASE _savepoint_") !=
+            sqlw::status::Condition::OK)
         {
             return sqlw::status::Code::RELEASE_ERROR;
         }


### PR DESCRIPTION
- Added int/double param validation error status code and corresponding condition;
- `Statement::Meta` structure to keep track of last successfuly prepared query and it's last successfuly bound parameter;
- `Transaction` now stores it's root statement's error message;
- Removed compile-time `operator()` overloads from `Statement` and `Transaction`, because code deduplication started to be a problem.